### PR TITLE
Fix readit enqueue workflow

### DIFF
--- a/.github/workflows/endpoint.readit.enqueue.yml
+++ b/.github/workflows/endpoint.readit.enqueue.yml
@@ -44,6 +44,7 @@ jobs:
       - name: 'Enqueue page to personal'
         env:
           OWNER_TOKEN: ${{ secrets.TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: endpoint-readit-send-to-personal '${{ github.event.inputs.url }}'
 
       - name: 'Enqueue page to queue v2'


### PR DESCRIPTION
It turns out that the current implementation does not work because API token is missing.

### How to Test?

https://github.com/parjong/endpoint/actions/runs/21477840488
```
gh workflow run "EP/readit/enqueue" \
  -f "url=https://arxiv.org/abs/2601.15153" \
  -r PR/fix_readit_enqueue_endpoint
```

위 URL은 https://github.com/parjong/endpoint/actions/runs/21457126739 에서 발췌