### PR TITLE
🔒 Add 60s timeout to urllib.request.urlopen to prevent DoS

### DIFF
--- a/src/endpoint/readit/core.py
+++ b/src/endpoint/readit/core.py
@@ -41,7 +41,7 @@ class Page:
 
 
 def page_of_(url: str) -> Page:
-    with urllib.request.urlopen(url) as response:
+    with urllib.request.urlopen(url, timeout=60) as response:
         page_html = response.read()
 
         page_url = urlparse(response.geturl())


### PR DESCRIPTION
🎯 **What:** The `urllib.request.urlopen` call in `src/endpoint/readit/core.py` was missing a timeout parameter.
⚠️ **Risk:** Without a timeout, the application could hang indefinitely if the remote server is slow or unresponsive. This could be exploited to cause a Denial of Service (DoS) by exhausting application resources.
🛡️ **Solution:** Added a `timeout=60` parameter to the `urllib.request.urlopen` call to ensure the request fails if it takes longer than 60 seconds. This is a local fix that avoids the risks of setting a global socket timeout.

---
*PR created automatically by Jules for task [17199733823197630099](https://jules.google.com/task/17199733823197630099) started by @parjong*