### PR TITLE
[Refactor] Implement Registry pattern with Fallback in send_to_personal

### DIFF
--- a/src/endpoint/readit/app/send_to_personal.py
+++ b/src/endpoint/readit/app/send_to_personal.py
@@ -61,20 +61,28 @@ class PersonalStorage:
         }
 
     def add_article(self, page: Page):
-        handler = self._handlers.get(page.kind)
-        if handler:
-            try:
-                handler(page)
-                return
-            except Exception as e:
-                logger.error(f"Failed to add article with {handler.__name__}: {e}")
-                logger.info("Falling back to add_other_article")
+        if self._add_known_article_if_possible(page):
+            return
 
         try:
             self.add_other_article(page)
         except Exception as e:
             logger.error(f"Failed to add article with add_other_article: {e}")
             raise
+
+    def _add_known_article_if_possible(self, page: Page) -> bool:
+        handler = self._handlers.get(page.kind)
+        if not handler:
+            return False
+
+        try:
+            handler(page)
+            return True
+        except Exception as e:
+            handler_name = getattr(handler, "__name__", str(handler))
+            logger.error(f"Failed to add article with {handler_name}: {e}")
+            logger.info("Falling back to add_other_article")
+            return False
 
     def add_arXiv_article(self, page: Page):
         summary = page.metadata.get("summary", "")


### PR DESCRIPTION
The article routing logic in `src/endpoint/readit/app/send_to_personal.py` was refactored from a conditional `if-else` block to a more extensible Registry pattern. 

Key changes:
- Added a `_handlers` dictionary to `PersonalStorage` to map article types (e.g., `arxiv`) to their respective processing methods.
- Introduced a central `add_article` method that manages dispatching.
- Implemented a fallback mechanism: if a specific handler is missing or its execution raises an exception, the system automatically falls back to the generic `add_other_article` handler.
- Updated the entry point to use this new dispatching logic.
- Improved error logging to handle objects without a `__name__` attribute (common in mocked environments).

Fixes #37

---
*PR created automatically by Jules for task [7681039178879821338](https://jules.google.com/task/7681039178879821338) started by @parjong*