### PR TITLE
Add issue template for wrong title summary

### DIFF
--- a/.github/ISSUE_TEMPLATE/wrong_summary.yml
+++ b/.github/ISSUE_TEMPLATE/wrong_summary.yml
@@ -1,7 +1,7 @@
 name: 😭 제목 요약이 이상해요
 description: 제목 요약이 이상할 때 제보해주세요.
 title: "😭 제목 요약이 이상해요"
-labels: ["태그: 보완 필요", "문제: 제목 요약"]
+labels: ["문제: 제목 요약", "태그: 보완 필요"]
 body:
   - type: input
     id: url
@@ -16,7 +16,7 @@ body:
     attributes:
       label: AS IS
       description: 현재 요약 결과를 입력해주세요.
-      placeholder: <... 현재 요약 결과 ...>
+      placeholder: 현재 요약 결과
       render: text
     validations:
       required: true


### PR DESCRIPTION
This change adds a new GitHub Issue template titled "😭 제목 요약이 이상해요" to help users report cases where the automated title summary is incorrect. The template provides a structured format including:
- URL of the page
- AS IS (Current summary)
- TO BE (Expected summary)

Fixes #50

---
*PR created automatically by Jules for task [13889816072845476799](https://jules.google.com/task/13889816072845476799) started by @parjong*