### PR TITLE
Add CLI to check URL existence in evaluation queue

### DIFF
--- a/fetch_result.json
+++ b/fetch_result.json
@@ -1,1 +1,0 @@
-{"url": "https://example.com/article", "html": "<html></html>", "trafilatura": {}}

--- a/fetch_result.json
+++ b/fetch_result.json
@@ -1,0 +1,1 @@
+{"url": "https://example.com/article", "html": "<html></html>", "trafilatura": {}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ endpoint-readit-send-to-personal = "endpoint.readit.app.send_to_personal:main"
 endpoint-readit-send-to-queue-v2 = "endpoint.readit.app.send_to_queue_v2:main"
 endpoint-readit-add-summary-to-eval-queue = "endpoint.readit.app.add_summary_to_eval_queue:main"
 endpoint-readit-fetch = "endpoint.readit.app.fetch:main"
+endpoint-readit-ensure-URL-not-in-eval-queue = "endpoint.readit.app.ensure_url_not_in_eval_queue:main"
 
 [build-system]
 requires = ["uv_build>=0.9.3,<0.10.0"]

--- a/src/endpoint/readit/app/ensure_url_not_in_eval_queue.py
+++ b/src/endpoint/readit/app/ensure_url_not_in_eval_queue.py
@@ -52,9 +52,8 @@ def main(fetch_result_path: str) -> None:
     if url_to_check in urls_in_queue:
         print("already in queue")
         sys.exit(1)
-    else:
-        print("not in queue")
-        sys.exit(0)
+
+    print("not in queue")
 
 
 if __name__ == "__main__":

--- a/src/endpoint/readit/app/ensure_url_not_in_eval_queue.py
+++ b/src/endpoint/readit/app/ensure_url_not_in_eval_queue.py
@@ -1,0 +1,61 @@
+import click
+from gql import Client
+from gql.transport.requests import RequestsHTTPTransport as HTTPTransport
+
+from logging import getLogger
+import os
+import sys
+
+from endpoint.readit.core import FetchResult
+from endpoint.readit.github import ListProjectV2ItemFieldValues
+
+logger = getLogger(__name__)
+
+
+class EvalQueue:
+    PROJECT_ID = "PVT_kwHOAOPA3c4BSAfY"
+    URL_FIELD_ID = "PVTF_lAHOAOPA3c4BSAfYzg_quM8"
+
+    def __init__(self, client: Client):
+        self._client = client
+
+    def get_urls(self) -> list[str]:
+        return ListProjectV2ItemFieldValues(
+            projectId=self.PROJECT_ID, fieldId=self.URL_FIELD_ID
+        ).execute(self._client)
+
+
+@click.command()
+@click.argument("fetch_result_path")
+def main(fetch_result_path: str) -> None:
+    logger.setLevel(os.environ.get("ENTRYPOINT_LOG_LEVEL", "INFO").upper())
+
+    github_graphql_url = os.environ["GITHUB_GRAPHQL_URL"]
+    owner_token = os.environ["OWNER_TOKEN"]
+
+    client = Client(
+        transport=HTTPTransport(
+            url=github_graphql_url,
+            headers={"Authorization": f"Bearer {owner_token}"},
+        )
+    )
+
+    with open(fetch_result_path, "r") as f:
+        fetch_result = FetchResult.model_validate_json(f.read())
+
+    url_to_check = str(fetch_result.url)
+    logger.info("Checking URL: %s", url_to_check)
+
+    queue = EvalQueue(client)
+    urls_in_queue = queue.get_urls()
+
+    if url_to_check in urls_in_queue:
+        print("already in queue")
+        sys.exit(1)
+    else:
+        print("not in queue")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/endpoint/readit/github.py
+++ b/src/endpoint/readit/github.py
@@ -60,6 +60,71 @@ class UpdateTextFieldValue:
         logger.debug(result)
 
 
+class ListProjectV2ItemFieldValues:
+    # https://docs.github.com/en/graphql/reference/objects#projectv2itemfieldvalueconnection
+    QUERY = gql("""
+    query ($projectId: ID!, $after: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              fieldValues(first: 20) {
+                nodes {
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                    field {
+                      ... on ProjectV2FieldCommon {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """)
+
+    def __init__(self, *, projectId: str, fieldId: str):
+        self._projectId = projectId
+        self._fieldId = fieldId
+
+    def execute(self, client) -> list[str]:
+        values = []
+        after = None
+        has_next_page = True
+
+        while has_next_page:
+            result = client.execute(
+                self.QUERY,
+                variable_values={
+                    "projectId": self._projectId,
+                    "after": after,
+                },
+            )
+            items_data = result["node"]["items"]
+            for item in items_data["nodes"]:
+                for field_value in item["fieldValues"]["nodes"]:
+                    if not field_value:
+                        continue
+                    if field_value.get("field", {}).get("id") == self._fieldId:
+                        text = field_value.get("text")
+                        if text is not None:
+                            values.append(text)
+
+            page_info = items_data["pageInfo"]
+            has_next_page = page_info["hasNextPage"]
+            after = page_info["endCursor"]
+
+        return values
+
+
 class UpdateDateFieldValue:
     # https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue
     QUERY = gql("""


### PR DESCRIPTION
This PR introduces a new CLI tool `endpoint-readit-ensure-URL-not-in-eval-queue` to prevent duplicate title summary evaluations.

Key changes:
- Added a `ListProjectV2ItemFieldValues` class in `src/endpoint/readit/github.py` to facilitate fetching field values (specifically URLs) from GitHub ProjectV2 items, supporting pagination.
- Created `src/endpoint/readit/app/ensure_url_not_in_eval_queue.py` which:
    - Accepts a `FetchResult` JSON file.
    - Queries the evaluation queue (Project `PVT_kwHOAOPA3c4BSAfY`) for existing URLs.
    - Exits with code 1 and "already in queue" if the URL exists.
    - Exits with code 0 and "not in queue" otherwise.
- Registered the new script in `pyproject.toml`.
- Verified the implementation with a mock test script and ensured linting compliance with `ruff`.

Fixes #60

---
*PR created automatically by Jules for task [11172344479007901759](https://jules.google.com/task/11172344479007901759) started by @parjong*