### PR TITLE
🔒 Fix command injection vulnerability in enqueue workflow

### DIFF
--- a/.github/workflows/endpoint.readit.enqueue.yml
+++ b/.github/workflows/endpoint.readit.enqueue.yml
@@ -14,10 +14,10 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    env:
+      INPUT_URL: ${{ github.event.inputs.url }}
     steps:
       - name: 'Show input url'
-        env:
-          INPUT_URL: ${{ github.event.inputs.url }}
         run: echo "$INPUT_URL"
 
       - uses: actions/checkout@v6
@@ -36,7 +36,6 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           FETCH_FILE: '/tmp/fetch.json'
           SUMMARY_FILE: '/tmp/summary.json'
-          INPUT_URL: ${{ github.event.inputs.url }}
         run: |
           endpoint-readit-fetch -o "$FETCH_FILE" "$INPUT_URL"
           endpoint-readit-summarize-other -o "$SUMMARY_FILE" "$FETCH_FILE"

--- a/.github/workflows/endpoint.readit.enqueue.yml
+++ b/.github/workflows/endpoint.readit.enqueue.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Show input url'
-        run: echo '${{ github.event.inputs.url }}'
+        env:
+          INPUT_URL: ${{ github.event.inputs.url }}
+        run: echo "$INPUT_URL"
 
       - uses: actions/checkout@v6
 
@@ -34,8 +36,9 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           FETCH_FILE: '/tmp/fetch.json'
           SUMMARY_FILE: '/tmp/summary.json'
+          INPUT_URL: ${{ github.event.inputs.url }}
         run: |
-          endpoint-readit-fetch -o "$FETCH_FILE" '${{ github.event.inputs.url }}'
+          endpoint-readit-fetch -o "$FETCH_FILE" "$INPUT_URL"
           endpoint-readit-summarize-other -o "$SUMMARY_FILE" "$FETCH_FILE"
           endpoint-readit-send-to-personal "$SUMMARY_FILE"
           endpoint-readit-send-to-queue-v2 "$SUMMARY_FILE"

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -39,9 +39,7 @@ def main(output_path: str, url: str) -> None:
 
     # Extract content using trafilatura
     # output_format="json" with with_metadata=True gives a JSON string with metadata
-    trafilatura_json_str = trafilatura.extract(
-        page_html_bytes, output_format="json", with_metadata=True
-    )
+    trafilatura_json_str = trafilatura.extract(page_html_bytes, output_format="json", with_metadata=True)
     if trafilatura_json_str:
         trafilatura_data = json.loads(trafilatura_json_str)
     else:
@@ -49,7 +47,9 @@ def main(output_path: str, url: str) -> None:
 
     # Prepare final output using Pydantic
     result = FetchResult(
-        url=normalized_url, html=page_html, trafilatura=trafilatura_data
+        url=normalized_url,
+        html=page_html,
+        trafilatura=trafilatura_data
     )
 
     # Write to output file
@@ -57,7 +57,6 @@ def main(output_path: str, url: str) -> None:
         f.write(result.model_dump_json(indent=2))
 
     logger.info("Saved raw data to '%s'", output_path)
-
 
 if __name__ == "__main__":
     main()

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -39,7 +39,9 @@ def main(output_path: str, url: str) -> None:
 
     # Extract content using trafilatura
     # output_format="json" with with_metadata=True gives a JSON string with metadata
-    trafilatura_json_str = trafilatura.extract(page_html_bytes, output_format="json", with_metadata=True)
+    trafilatura_json_str = trafilatura.extract(
+        page_html_bytes, output_format="json", with_metadata=True
+    )
     if trafilatura_json_str:
         trafilatura_data = json.loads(trafilatura_json_str)
     else:
@@ -47,9 +49,7 @@ def main(output_path: str, url: str) -> None:
 
     # Prepare final output using Pydantic
     result = FetchResult(
-        url=normalized_url,
-        html=page_html,
-        trafilatura=trafilatura_data
+        url=normalized_url, html=page_html, trafilatura=trafilatura_data
     )
 
     # Write to output file
@@ -57,6 +57,7 @@ def main(output_path: str, url: str) -> None:
         f.write(result.model_dump_json(indent=2))
 
     logger.info("Saved raw data to '%s'", output_path)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
🎯 **What:** The workflow file `.github/workflows/endpoint.readit.enqueue.yml` contained a command injection vulnerability. The untrusted user input `${{ github.event.inputs.url }}` was being directly interpolated into shell commands.

⚠️ **Risk:** An attacker could exploit this by providing a maliciously crafted URL containing shell metacharacters (such as `;`, `|`, `&`, `$()`, etc.). Because the interpolation happens before the shell script executes, the runner would execute the attacker's arbitrary commands, potentially compromising the build environment, accessing secrets, or performing unauthorized actions.

🛡️ **Solution:** The fix replaces the direct string interpolation with intermediate environment variables. The input URL is now bound to the `INPUT_URL` environment variable within the step's `env` block. The shell script then references this variable securely as `"$INPUT_URL"`. This is the standard, secure approach recommended by GitHub to prevent command injection in Actions.

---
*PR created automatically by Jules for task [3247009571730565991](https://jules.google.com/task/3247009571730565991) started by @parjong*