### PR TITLE
Improve EP/readit/enqueue workflow for duplicate prevention

### DIFF
--- a/.github/workflows/endpoint.readit.enqueue.yml
+++ b/.github/workflows/endpoint.readit.enqueue.yml
@@ -30,21 +30,31 @@ jobs:
       - name: 'Install server'
         run: uv tool install --force ./
 
+        # TODO Reduce duplication
+      - name: 'Fetch'
+        env:
+          OWNER_TOKEN: ${{ secrets.TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # This variable is used during module loading
+          # TODO Find a way to remove this redundant "GEMINI_API_KEY"
+          FETCH_FILE: '/tmp/fetch.json'
+        run: |
+          endpoint-readit-fetch -o "$FETCH_FILE" "$INPUT_URL"
+          endpoint-readit-ensure-URL-not-in-eval-queue "$FETCH_FILE"
+
       - name: 'Enqueue'
         env:
           OWNER_TOKEN: ${{ secrets.TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_GRAPHQL_URL: "https://api.github.com/graphql"
-          INPUT_URL: ${{ github.event.inputs.url }}
           FETCH_FILE: '/tmp/fetch.json'
           SUMMARY_FILE: '/tmp/summary.json'
         run: |
-          endpoint-readit-fetch -o "$FETCH_FILE" "$INPUT_URL"
-          endpoint-readit-ensure-URL-not-in-eval-queue "$FETCH_FILE"
           endpoint-readit-summarize-other -o "$SUMMARY_FILE" "$FETCH_FILE"
           endpoint-readit-add-summary-to-eval-queue "$SUMMARY_FILE"
           endpoint-readit-send-to-personal "$SUMMARY_FILE"
           endpoint-readit-send-to-queue-v2 "$SUMMARY_FILE"
+        continue-on-error: true
+        # 'continue-on-error' ensures that a failure from one command not to affect the others
     # steps/ END
   # run/ END
 # jobs/ END

--- a/.github/workflows/endpoint.readit.enqueue.yml
+++ b/.github/workflows/endpoint.readit.enqueue.yml
@@ -34,15 +34,17 @@ jobs:
         env:
           OWNER_TOKEN: ${{ secrets.TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_GRAPHQL_URL: "https://api.github.com/graphql"
+          INPUT_URL: ${{ github.event.inputs.url }}
           FETCH_FILE: '/tmp/fetch.json'
           SUMMARY_FILE: '/tmp/summary.json'
         run: |
           endpoint-readit-fetch -o "$FETCH_FILE" "$INPUT_URL"
+          endpoint-readit-ensure-URL-not-in-eval-queue "$FETCH_FILE"
           endpoint-readit-summarize-other -o "$SUMMARY_FILE" "$FETCH_FILE"
+          endpoint-readit-add-summary-to-eval-queue "$SUMMARY_FILE"
           endpoint-readit-send-to-personal "$SUMMARY_FILE"
           endpoint-readit-send-to-queue-v2 "$SUMMARY_FILE"
-        continue-on-error: true
-        # 'continue-on-error' ensures that a failure from one command not to affect the others
     # steps/ END
   # run/ END
 # jobs/ END

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -39,7 +39,9 @@ def main(output_path: str, url: str) -> None:
 
     # Extract content using trafilatura
     # output_format="json" with with_metadata=True gives a JSON string with metadata
-    trafilatura_json_str = trafilatura.extract(page_html_bytes, output_format="json", with_metadata=True)
+    trafilatura_json_str = trafilatura.extract(
+        page_html_bytes, output_format="json", with_metadata=True
+    )
     if trafilatura_json_str:
         trafilatura_data = json.loads(trafilatura_json_str)
     else:
@@ -47,9 +49,7 @@ def main(output_path: str, url: str) -> None:
 
     # Prepare final output using Pydantic
     result = FetchResult(
-        url=normalized_url,
-        html=page_html,
-        trafilatura=trafilatura_data
+        url=normalized_url, html=page_html, trafilatura=trafilatura_data
     )
 
     # Write to output file
@@ -57,6 +57,7 @@ def main(output_path: str, url: str) -> None:
         f.write(result.model_dump_json(indent=2))
 
     logger.info("Saved raw data to '%s'", output_path)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The `EP/readit/enqueue` workflow has been improved to prevent short-term duplicate registrations. 
After fetching the URL content, the workflow now executes `endpoint-readit-ensure-URL-not-in-eval-queue` to verify if the URL is already present in the evaluation queue. If it is, the workflow stops.
Additionally, after summarizing the content, `endpoint-readit-add-summary-to-eval-queue` is called to register the summary results. 
Environment variables `GITHUB_GRAPHQL_URL` and `INPUT_URL` were added to support these new steps, and `continue-on-error: true` was removed to ensure the workflow fails correctly when a duplicate is found.
Some files were reformatted by the pre-commit hooks.

Fixes #65

---
*PR created automatically by Jules for task [4241188262586664646](https://jules.google.com/task/4241188262586664646) started by @parjong*