### PR TITLE
Relocate Gemini LLM dependency to app-specific script

### DIFF
--- a/src/endpoint/readit/app/summarize_other.py
+++ b/src/endpoint/readit/app/summarize_other.py
@@ -18,6 +18,15 @@ logger = getLogger(__name__)
 logger.setLevel(os.environ.get("ENTRYPOINT_LOG_LEVEL", "INFO").upper())
 
 
+class Summary(BaseModel):
+    title: str = Field(
+        description="The title of concise main title of the article or page"
+    )
+    date: str = Field(
+        description="The issue or publication date as YYYY/MM/DD format (????/??/?? if unknown)"
+    )
+
+
 _PROMPT = ChatPromptTemplate.from_template("""
     Analyze the following content from a webpage and extract two pieces of information:
     1. The concise main title of the article or page.
@@ -28,17 +37,6 @@ _PROMPT = ChatPromptTemplate.from_template("""
 
     Content: {content}
     """)
-
-
-class Summary(BaseModel):
-    title: str = Field(
-        description="The title of concise main title of the article or page"
-    )
-    date: str = Field(
-        description="The issue or publication date as YYYY/MM/DD format (????/??/?? if unknown)"
-    )
-
-
 _STRUCTURED_LLM = ChatGoogleGenerativeAI(
     model="gemini-2.5-flash"
 ).with_structured_output(Summary)

--- a/src/endpoint/readit/app/summarize_other.py
+++ b/src/endpoint/readit/app/summarize_other.py
@@ -5,14 +5,36 @@ import os
 from urllib.parse import urlparse
 
 import click
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel
+from pydantic import Field
 
 from endpoint.readit.core import Page
 from endpoint.readit.core import FetchResult
-from endpoint.readit.core import page_of_
 
 
 logger = getLogger(__name__)
 logger.setLevel(os.environ.get("ENTRYPOINT_LOG_LEVEL", "INFO").upper())
+
+
+class Summary(BaseModel):
+    title: str = Field(
+        description="The title of concise main title of the article or page"
+    )
+    date: str = Field(
+        description="The issue or publication date as YYYY/MM/DD format (????/??/?? if unknown)"
+    )
+
+
+def page_of_(fetch_result: FetchResult, chain) -> Page:
+    summary = chain.invoke({"content": fetch_result.html})
+
+    return Page(
+        url=urlparse(str(fetch_result.url)),
+        title=summary.title,
+        date=summary.date,
+    )
 
 
 @click.command()
@@ -44,7 +66,22 @@ def main(output_path: str, fetch_result_path: str) -> None:
             },
         )
     else:
-        page = page_of_(fetch_result)
+        prompt = ChatPromptTemplate.from_template("""
+            Analyze the following content from a webpage and extract two pieces of information:
+            1. The concise main title of the article or page.
+            2. The issue or publication date as YYYY/MM/DD format (if available).
+               - If not available, state "????/??/??".
+
+            Format your answer as a JSON object with keys "date" and "title".
+
+            Content: {content}
+            """)
+        structured_llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash"
+        ).with_structured_output(Summary)
+        chain = prompt | structured_llm
+
+        page = page_of_(fetch_result, chain)
 
     logger.info("Result: '%s'", page)
 

--- a/src/endpoint/readit/app/summarize_other.py
+++ b/src/endpoint/readit/app/summarize_other.py
@@ -18,6 +18,18 @@ logger = getLogger(__name__)
 logger.setLevel(os.environ.get("ENTRYPOINT_LOG_LEVEL", "INFO").upper())
 
 
+_PROMPT = ChatPromptTemplate.from_template("""
+    Analyze the following content from a webpage and extract two pieces of information:
+    1. The concise main title of the article or page.
+    2. The issue or publication date as YYYY/MM/DD format (if available).
+       - If not available, state "????/??/??".
+
+    Format your answer as a JSON object with keys "date" and "title".
+
+    Content: {content}
+    """)
+
+
 class Summary(BaseModel):
     title: str = Field(
         description="The title of concise main title of the article or page"
@@ -27,8 +39,14 @@ class Summary(BaseModel):
     )
 
 
-def page_of_(fetch_result: FetchResult, chain) -> Page:
-    summary = chain.invoke({"content": fetch_result.html})
+_STRUCTURED_LLM = ChatGoogleGenerativeAI(
+    model="gemini-2.5-flash"
+).with_structured_output(Summary)
+_CHAIN = _PROMPT | _STRUCTURED_LLM
+
+
+def page_of_(fetch_result: FetchResult) -> Page:
+    summary = _CHAIN.invoke({"content": fetch_result.html})
 
     return Page(
         url=urlparse(str(fetch_result.url)),
@@ -66,22 +84,7 @@ def main(output_path: str, fetch_result_path: str) -> None:
             },
         )
     else:
-        prompt = ChatPromptTemplate.from_template("""
-            Analyze the following content from a webpage and extract two pieces of information:
-            1. The concise main title of the article or page.
-            2. The issue or publication date as YYYY/MM/DD format (if available).
-               - If not available, state "????/??/??".
-
-            Format your answer as a JSON object with keys "date" and "title".
-
-            Content: {content}
-            """)
-        structured_llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash"
-        ).with_structured_output(Summary)
-        chain = prompt | structured_llm
-
-        page = page_of_(fetch_result, chain)
+        page = page_of_(fetch_result)
 
     logger.info("Result: '%s'", page)
 

--- a/src/endpoint/readit/core.py
+++ b/src/endpoint/readit/core.py
@@ -1,24 +1,12 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel
-from pydantic import Field
 from pydantic import HttpUrl
 from typing import Any
 from urllib.parse import ParseResult as URL
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
-
-
-class Summary(BaseModel):
-    title: str = Field(
-        description="The title of concise main title of the article or page"
-    )
-    date: str = Field(
-        description="The issue or publication date as YYYY/MM/DD format (????/??/?? if unknown)"
-    )
 
 
 class FetchResult(BaseModel):
@@ -56,29 +44,3 @@ class Page:
             kind=d.get("kind", "other"),
             metadata=d.get("metadata", {}),
         )
-
-
-_PROMPT = ChatPromptTemplate.from_template("""
-    Analyze the following content from a webpage and extract two pieces of information:
-    1. The concise main title of the article or page.
-    2. The issue or publication date as YYYY/MM/DD format (if available).
-       - If not available, state "????/??/??".
-
-    Format your answer as a JSON object with keys "date" and "title".
-
-    Content: {content}
-    """)
-_STRUCTURED_LLM = ChatGoogleGenerativeAI(
-    model="gemini-2.5-flash"
-).with_structured_output(Summary)
-_CHAIN = _PROMPT | _STRUCTURED_LLM
-
-
-def page_of_(fetch_result: FetchResult) -> Page:
-    summary = _CHAIN.invoke({"content": fetch_result.html})
-
-    return Page(
-        url=urlparse(str(fetch_result.url)),
-        title=summary.title,
-        date=summary.date,
-    )


### PR DESCRIPTION
Moved Gemini LLM dependency and initialization from `core.py` to `summarize_other.py` to prevent unnecessary API key requirements in other scripts. verified that `core.py` can be imported without the API key and `summarize_other.py` still functions correctly.

Fixes #67

---
*PR created automatically by Jules for task [6161839347823505875](https://jules.google.com/task/6161839347823505875) started by @parjong*