### PR TITLE
Add baseline endpoint.readit.core tests

### DIFF
--- a/.github/workflows/pull.on_default_branch.yml
+++ b/.github/workflows/pull.on_default_branch.yml
@@ -17,6 +17,9 @@ jobs:
           version: 0.9.22 # Latest as of 2026 Jan 07
         # with/ END
 
+      # TODO: Currently we use `uvx` directly, but in the future we should install pre-commit via `uv tool` and run it in 2 stages:
+      # 1. `pre-commit run` (default, only for changed files)
+      # 2. `pre-commit run --hook-stage manual` (for global hooks like tests)
       - run: uvx --from pre-commit==4.5.1 pre-commit run --all-files
     # steps/ END
   # run/ END

--- a/.github/workflows/pull.on_default_branch.yml
+++ b/.github/workflows/pull.on_default_branch.yml
@@ -20,7 +20,7 @@ jobs:
       # TODO: Currently we use `uvx` directly, but in the future we should install pre-commit via `uv tool` and run it in 2 stages:
       # 1. `pre-commit run` (default, only for changed files)
       # 2. `pre-commit run --hook-stage manual` (for global hooks like tests)
-      - run: uvx --from pre-commit==4.5.1 pre-commit run --all-files
+      - run: uvx --from pre-commit==4.5.1 pre-commit run --all-files --show-diff-on-failure
     # steps/ END
   # run/ END
 # jobs/ END

--- a/.github/workflows/pull.on_default_branch.yml
+++ b/.github/workflows/pull.on_default_branch.yml
@@ -17,7 +17,7 @@ jobs:
           version: 0.9.22 # Latest as of 2026 Jan 07
         # with/ END
 
-      - run: uvx --from pre-commit==4.5.1 pre-commit run
+      - run: uvx --from pre-commit==4.5.1 pre-commit run --all-files
     # steps/ END
   # run/ END
 # jobs/ END

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,14 @@ repos:
         language: system
         entry: uv run ruff check
       # ruff-check/ END
+
+      - id: pytest
+        name: 'Run pytest'
+        types: [python]
+        language: system
+        entry: uv run pytest
+        pass_filenames: false
+      # pytest/ END
     # hooks/ END
   # local/ END
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,15 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.3",
     "ruff==0.14.10",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]
+
+[tool.pyright]
+typeCheckingMode = "basic"
+extraPaths = ["src"]

--- a/src/endpoint/readit/app/summarize_other.py
+++ b/src/endpoint/readit/app/summarize_other.py
@@ -37,8 +37,8 @@ _PROMPT = ChatPromptTemplate.from_template("""
     3. **Key Sentences**: Identify up to 3 most important sentences that represent the core message of the content.
 
     **Critical Constraints for Key Sentences:**
-    - Each sentence MUST be extracted EXACTLY as it appears in the original content. 
-    - Do NOT summarize or rephrase the sentences. 
+    - Each sentence MUST be extracted EXACTLY as it appears in the original content.
+    - Do NOT summarize or rephrase the sentences.
     - Provide them as a list of strings.
 
     Format your answer as a JSON object with keys "date", "title", and "key_sentences".

--- a/tests/endpoint/readit/test_core.py
+++ b/tests/endpoint/readit/test_core.py
@@ -1,4 +1,3 @@
-
 from urllib.parse import urlparse
 from endpoint.readit.core import Page
 
@@ -10,11 +9,11 @@ def test_page_fromdict_other():
         "title": "Example Title",
         "date": "2026/04/10",
         "kind": "other",
-        "metadata": {"some": "value"}
+        "metadata": {"some": "value"},
     }
-    
+
     page = Page.fromdict(payload)
-    
+
     assert page.kind == "other"
     assert page.title == "Example Title"
     assert page.date == "2026/04/10"
@@ -26,7 +25,7 @@ def test_page_fromdict_other():
 
 
 def test_page_fromdict_arxiv():
-    """Test parsing an 'arxiv' Page. 
+    """Test parsing an 'arxiv' Page.
     Notes from Issue #28: date format should be YYYY, it can't be UNKNOWN.
     We also expect paper_id and abstract around metadata for now.
     """
@@ -35,14 +34,11 @@ def test_page_fromdict_arxiv():
         "title": "Some Paper Title",
         "date": "2026",
         "kind": "arxiv",
-        "metadata": {
-            "paper_id": "2602.04118",
-            "abstract": "This is a great paper."
-        }
+        "metadata": {"paper_id": "2602.04118", "abstract": "This is a great paper."},
     }
-    
+
     page = Page.fromdict(payload)
-    
+
     assert page.kind == "arxiv"
     assert page.title == "Some Paper Title"
     assert page.date == "2026"
@@ -58,7 +54,7 @@ def test_page_direct_instantiation():
         title="GitHub",
         date="UNKNOWN",
         kind="other",
-        metadata={}
+        metadata={},
     )
     assert page.kind == "other"
     assert page.date == "UNKNOWN"

--- a/tests/endpoint/readit/test_core.py
+++ b/tests/endpoint/readit/test_core.py
@@ -1,0 +1,65 @@
+
+from urllib.parse import urlparse
+from endpoint.readit.core import Page
+
+
+def test_page_fromdict_other():
+    """Test parsing an 'other' Page from a dictionary payload."""
+    payload = {
+        "url": "https://example.com/foo",
+        "title": "Example Title",
+        "date": "2026/04/10",
+        "kind": "other",
+        "metadata": {"some": "value"}
+    }
+    
+    page = Page.fromdict(payload)
+    
+    assert page.kind == "other"
+    assert page.title == "Example Title"
+    assert page.date == "2026/04/10"
+    assert page.url_as_str() == "https://example.com/foo"
+    # asdict shouldn't lose the metadata
+    assert page.asdict() == payload
+    # Validate inner URL object representation
+    assert page.url.netloc == "example.com"
+
+
+def test_page_fromdict_arxiv():
+    """Test parsing an 'arxiv' Page. 
+    Notes from Issue #28: date format should be YYYY, it can't be UNKNOWN.
+    We also expect paper_id and abstract around metadata for now.
+    """
+    payload = {
+        "url": "https://arxiv.org/abs/2602.04118",
+        "title": "Some Paper Title",
+        "date": "2026",
+        "kind": "arxiv",
+        "metadata": {
+            "paper_id": "2602.04118",
+            "abstract": "This is a great paper."
+        }
+    }
+    
+    page = Page.fromdict(payload)
+    
+    assert page.kind == "arxiv"
+    assert page.title == "Some Paper Title"
+    assert page.date == "2026"
+    assert page.url_as_str() == "https://arxiv.org/abs/2602.04118"
+    assert page.asdict() == payload
+    assert page.metadata["paper_id"] == "2602.04118"
+
+
+def test_page_direct_instantiation():
+    """Test creating a Page directly via constructor."""
+    page = Page(
+        url=urlparse("https://github.com"),
+        title="GitHub",
+        date="UNKNOWN",
+        kind="other",
+        metadata={}
+    )
+    assert page.kind == "other"
+    assert page.date == "UNKNOWN"
+    assert page.url_as_str() == "https://github.com"


### PR DESCRIPTION
Let's add baseline validation tests for `Page` model and structure before starting the Discriminated Union refactoring.

Related to #28