### PR TITLE
Add artifact upload to readit enqueue workflow

### DIFF
--- a/.github/workflows/endpoint.readit.enqueue.yml
+++ b/.github/workflows/endpoint.readit.enqueue.yml
@@ -55,6 +55,15 @@ jobs:
           endpoint-readit-send-to-queue-v2 "$SUMMARY_FILE"
         continue-on-error: true
         # 'continue-on-error' ensures that a failure from one command not to affect the others
+      - name: 'Upload artifacts'
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: readit-artifacts
+          path: |
+            /tmp/fetch.json
+            /tmp/summary.json
+          if-no-files-found: ignore
     # steps/ END
   # run/ END
 # jobs/ END

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Makefile
 # - https://antigravity.google/docs/rules-workflows
 # - https://antigravity.google/docs/skills
 /.agents
+!/.agents/skills/
+!/.agents/skills/antigravity-tips/
+!/.agents/skills/antigravity-tips/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ Makefile
 # - https://antigravity.google/docs/rules-workflows
 # - https://antigravity.google/docs/skills
 /.agents
-!/.agents/skills/
-!/.agents/skills/antigravity-tips/
-!/.agents/skills/antigravity-tips/SKILL.md


### PR DESCRIPTION
Let's store fetch.json and summary.json as artifacts in the readit enqueue workflow.

For better observability and easier debugging, I've updated the `readit enqueue` workflow to upload intermediate files (`fetch.json` and `summary.json`) as GitHub Actions Artifacts.

Key adjustments:
- Applied `if: always()` to ensure artifacts are captured even if later steps (like `Enqueue` or `Summarize`) fail.
- Configured `if-no-files-found: ignore` to prevent the workflow from failing if a specific file was not generated in a previous step.
