### PR TITLE
Replace id suffix with oid

### DIFF
--- a/src/endpoint/readit/app/send_to_personal.py
+++ b/src/endpoint/readit/app/send_to_personal.py
@@ -124,7 +124,7 @@ class PersonalStorage:
             title=title,
             body=body,
         ).execute(self._client)
-        bb.personal_archive.issue_id = issue_resp.id
+        bb.personal_archive.issue_oid = issue_resp.id
         bb.personal_archive.issue_url = issue_resp.url
 
     def add_other_article(self, bb: Blackboard):
@@ -137,8 +137,8 @@ class PersonalStorage:
             body=body,
         ).execute(self._client)
 
-        issue_id = issue_resp.id
-        bb.personal_archive.issue_id = issue_id
+        issue_oid = issue_resp.id
+        bb.personal_archive.issue_oid = issue_oid
         bb.personal_archive.issue_url = issue_resp.url
 
         # Add key sentences as a comment if available
@@ -146,10 +146,10 @@ class PersonalStorage:
         if key_sentences:
             comment_body = "\n".join([f"- {s}" for s in key_sentences])
             comment_resp = AddIssueComment(
-                subjectId=issue_id,
+                subjectId=issue_oid,
                 body=comment_body,
             ).execute(self._client)
-            bb.personal_archive.comment_id = comment_resp.id
+            bb.personal_archive.comment_oid = comment_resp.id
             bb.personal_archive.comment_url = comment_resp.url
 
 

--- a/src/endpoint/readit/app/send_to_queue_v2.py
+++ b/src/endpoint/readit/app/send_to_queue_v2.py
@@ -82,17 +82,17 @@ class Queue:
         body = bb.url_as_str()
 
         # Enforce that key sentences comment has been created
-        comment_id = bb.personal_archive.comment_id
-        if not comment_id:
+        comment_oid = bb.personal_archive.comment_oid
+        if not comment_oid:
             raise ValueError(
-                f"comment_id is required for kind 'other'. Blackboard: {bb.url_as_str()}"
+                f"comment_oid is required for kind 'other'. Blackboard: {bb.url_as_str()}"
             )
 
         # Reuse existing issue if already created by personal archive, fallback to Draft Issue
-        issue_id = bb.personal_archive.issue_id
-        if issue_id:
+        issue_oid = bb.personal_archive.issue_oid
+        if issue_oid:
             item_id = AddProjectV2ItemById(
-                projectId=self.OTHER_PROJECT_ID, contentId=issue_id
+                projectId=self.OTHER_PROJECT_ID, contentId=issue_oid
             ).execute(self._client)
         else:
             item_id = AddProjectV2DraftIssue(
@@ -128,7 +128,7 @@ class Queue:
             projectId=self.OTHER_PROJECT_ID,
             itemId=item_id,
             fieldId=self.OTHER_KEY_SENTENCES_ID_FIELD_ID,
-            value=comment_id,
+            value=comment_oid,
         ).execute(self._client)
 
     def _add_arxiv(self, bb: Blackboard):
@@ -144,10 +144,10 @@ class Queue:
         body = "\n".join(lines)
 
         # Reuse existing issue if already created by personal archive, fallback to Draft Issue
-        issue_id = bb.personal_archive.issue_id
-        if issue_id:
+        issue_oid = bb.personal_archive.issue_oid
+        if issue_oid:
             item_id = AddProjectV2ItemById(
-                projectId=self.ARXIV_PROJECT_ID, contentId=issue_id
+                projectId=self.ARXIV_PROJECT_ID, contentId=issue_oid
             ).execute(self._client)
         else:
             item_id = AddProjectV2DraftIssue(

--- a/src/endpoint/readit/core.py
+++ b/src/endpoint/readit/core.py
@@ -18,13 +18,12 @@ class ArxivMetadata(BaseModel):
 
 
 class PersonalArchiveMetadata(BaseModel):
-    # TODO: Rename issue_id to issue_oid and comment_id to comment_oid for consistency with GitHub terminology
-    issue_id: str | None = None
+    issue_oid: str | None = None
     # 'str' is used instead of 'HttpUrl' to avoid the complexity of Pydantic's Url objects
     # (e.g., in logging or f-strings) while still ensuring data integrity
     # through validation during assignment.
     issue_url: str | None = None
-    comment_id: str | None = None
+    comment_oid: str | None = None
     comment_url: str | None = None
 
     @field_validator("issue_url", "comment_url")


### PR DESCRIPTION
Let's use "oid" suffix instead of "id" to make its role clear.