### PR TITLE
Record original content as a comment

### DIFF
--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -8,6 +8,7 @@ from urllib.parse import urlunparse
 
 import click
 import trafilatura
+from bs4 import BeautifulSoup, NavigableString
 from curl_cffi import requests
 
 from endpoint.readit.core import Blackboard
@@ -23,6 +24,24 @@ class BaseProcessor:
         return html_bytes
 
     def postprocess_text(self, text: str) -> str:
+        # Merge inline code backticks followed by newlines and a lowercase/Korean character
+        pattern_backtick = r"`([^`\n]+)`\s*\n+\s*([가-힣a-z,.?!~])"
+        text = re.sub(pattern_backtick, r"`\1` \2", text)
+
+        # Merge general accidental newlines inside sentences
+        lines = text.splitlines()
+        merged_lines = []
+        for line in lines:
+            if merged_lines and merged_lines[-1].strip() and line.strip():
+                prev_line = merged_lines[-1].rstrip()
+                curr_line = line.strip()
+                if not prev_line.endswith(
+                    (".", "!", "?", ":", "#", "-", "*")
+                ) and re.match(r"^[가-힣a-z]", curr_line):
+                    merged_lines[-1] = prev_line + " " + curr_line
+                    continue
+            merged_lines.append(line)
+        text = "\n".join(merged_lines)
         return text
 
 
@@ -75,24 +94,8 @@ class GeekNewsProcessor(BaseProcessor):
         # Merge the top link and title header for GeekNews into a single unified clickable header
         text = self._merge_link_and_header(text)
 
-        # Merge inline code backticks followed by newlines and a lowercase/Korean character
-        pattern_backtick = r"`([^`\n]+)`\s*\n+\s*([가-힣a-z,.?!~])"
-        text = re.sub(pattern_backtick, r"`\1` \2", text)
-
-        # Merge general accidental newlines inside sentences
-        lines = text.splitlines()
-        merged_lines = []
-        for line in lines:
-            if merged_lines and merged_lines[-1].strip() and line.strip():
-                prev_line = merged_lines[-1].rstrip()
-                curr_line = line.strip()
-                if not prev_line.endswith(
-                    (".", "!", "?", ":", "#", "-", "*")
-                ) and re.match(r"^[가-힣a-z]", curr_line):
-                    merged_lines[-1] = prev_line + " " + curr_line
-                    continue
-            merged_lines.append(line)
-        text = "\n".join(merged_lines)
+        # Run parent class postprocessing (backtick and general sentence merging)
+        text = super().postprocess_text(text)
 
         # Remove empty lines between consecutive list items to keep list blocks compact
         lines = text.splitlines()
@@ -111,11 +114,38 @@ class GeekNewsProcessor(BaseProcessor):
                         new_lines.pop()
             new_lines.append(line)
         text = "\n".join(new_lines)
+        # Strip empty bullets followed by markdown headings
+        pattern_empty_bullet = re.compile(r"^\s*[-\*\+]\s*\n+\s*(#+)", re.MULTILINE)
+        text = pattern_empty_bullet.sub(r"\1", text)
         return text
 
 
 class LinkedInProcessor(BaseProcessor):
     """LinkedIn specific HTML and text pre/postprocessor."""
+
+    def preprocess_html(self, html_bytes: bytes) -> bytes:
+        try:
+            html = html_bytes.decode("utf-8", errors="replace")
+            soup = BeautifulSoup(html, "html.parser")
+            commentary = soup.find(
+                attrs={"data-test-id": "main-feed-activity-card__commentary"}
+            )
+            if commentary:
+                for text_node in list(commentary.find_all(string=True)):
+                    if "\n" in text_node:
+                        text_str = text_node
+                        parts = text_str.split("\n\n")
+                        new_nodes = []
+                        for idx, part in enumerate(parts):
+                            if part:
+                                clean_part = part.replace("\n", " ")
+                                new_nodes.append(NavigableString(clean_part))
+                            if idx < len(parts) - 1:
+                                new_nodes.append(soup.new_tag("br"))
+                        text_node.replace_with(*new_nodes)
+            return str(soup).encode("utf-8")
+        except Exception:
+            return html_bytes
 
     def postprocess_text(self, text: str) -> str:
         # Match markdown links containing comments or comment_actor in their target and strip everything from there
@@ -130,6 +160,8 @@ class LinkedInProcessor(BaseProcessor):
             r"^\s*(?:={3,}|-{3,}|_{3,}|\*{3,})\s*$", re.MULTILINE
         )
         text = pattern_separator.sub("", text)
+        # Run parent class postprocessing (backtick and general sentence merging)
+        text = super().postprocess_text(text)
         return text
 
 

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -16,58 +16,69 @@ logger = getLogger(__name__)
 logger.setLevel(os.environ.get("ENTRYPOINT_LOG_LEVEL", "INFO").upper())
 
 
-def preprocess_html(html_bytes: bytes, url: str) -> bytes:
-    """Preprocess HTML to preserve list item separation and newlines in trafilatura specifically for Geek News."""
-    if "news.hada.io" not in url:
+class BaseProcessor:
+    """Base class for HTML and text pre/postprocessing."""
+
+    def preprocess_html(self, html_bytes: bytes) -> bytes:
         return html_bytes
 
-    try:
-        html = html_bytes.decode("utf-8", errors="replace")
-        # Replace list items with paragraph tags to preserve list item separation and newlines
-        html = re.sub(r"<li>", "<p>- ", html, flags=re.IGNORECASE)
-        html = re.sub(r"</li>", "</p>", html, flags=re.IGNORECASE)
-        # Replace br tags with paragraph boundaries to preserve single line breaks
-        html = re.sub(r"<br\s*/?>", "</p><p>", html, flags=re.IGNORECASE)
-        return html.encode("utf-8")
-    except Exception:
-        return html_bytes
-
-
-def merge_link_and_header(text: str, url: str) -> str:
-    """If Geek News, merge the top link and the title header into a single unified clickable header."""
-    if "news.hada.io" not in url:
+    def postprocess_text(self, text: str) -> str:
         return text
 
-    link_match = re.search(r"^\[([^\]]+)\]\((https?://[^\)]+)\)", text.strip())
-    if link_match:
-        link_text, link_url = link_match.groups()
-        header_match = re.search(r"#\s+([^\n]+)", text)
-        if header_match:
-            header_text = header_match.group(1).strip()
-            # Remove the top link and its trailing spaces/newlines
-            cleaned_text = re.sub(r"^\[[^\]]+\]\([^\)]+\)\s*", "", text.strip())
-            # Replace '# Title' with '# [Title](URL)'
-            return re.sub(
-                r"#\s+" + re.escape(header_text),
-                f"# [{header_text}]({link_url})",
-                cleaned_text,
-                count=1,
-            )
-    return text
+
+class DefaultProcessor(BaseProcessor):
+    """Default processor that performs no modifications."""
+
+    pass
 
 
-def postprocess_text(text: str, url: str) -> str:
-    """Postprocess the extracted markdown text based on URL specific rules."""
-    if "news.hada.io" in url:
+class GeekNewsProcessor(BaseProcessor):
+    """Geek News specific HTML and text pre/postprocessor."""
+
+    def preprocess_html(self, html_bytes: bytes) -> bytes:
+        try:
+            html = html_bytes.decode("utf-8", errors="replace")
+            # Replace list items with paragraph tags to preserve list item separation and newlines
+            html = re.sub(r"<li>", "<p>- ", html, flags=re.IGNORECASE)
+            html = re.sub(r"</li>", "</p>", html, flags=re.IGNORECASE)
+            # Replace br tags with paragraph boundaries to preserve single line breaks
+            html = re.sub(r"<br\s*/?>", "</p><p>", html, flags=re.IGNORECASE)
+            return html.encode("utf-8")
+        except Exception:
+            return html_bytes
+
+    def _merge_link_and_header(self, text: str) -> str:
+        """Merge the top link and the title header into a single unified clickable header."""
+        link_match = re.search(r"^\[([^\]]+)\]\((https?://[^\)]+)\)", text.strip())
+        if link_match:
+            link_text, link_url = link_match.groups()
+            header_match = re.search(r"#\s+([^\n]+)", text)
+            if header_match:
+                header_text = header_match.group(1).strip()
+                # Remove the top link and its trailing spaces/newlines
+                cleaned_text = re.sub(r"^\[[^\]]+\]\([^\)]+\)\s*", "", text.strip())
+                # Replace '# Title' with '# [Title](URL)'
+                return re.sub(
+                    r"#\s+" + re.escape(header_text),
+                    f"# [{header_text}]({link_url})",
+                    cleaned_text,
+                    count=1,
+                )
+        return text
+
+    def postprocess_text(self, text: str) -> str:
         # Strip comments section from GeekNews
         for delimiter in ["## 댓글과 토론", "## 댓글"]:
             if delimiter in text:
                 text = text.split(delimiter)[0].strip()
+
         # Merge the top link and title header for GeekNews into a single unified clickable header
-        text = merge_link_and_header(text, url)
+        text = self._merge_link_and_header(text)
+
         # Merge inline code backticks followed by newlines and a lowercase/Korean character
         pattern_backtick = r"`([^`\n]+)`\s*\n+\s*([가-힣a-z,.?!~])"
         text = re.sub(pattern_backtick, r"`\1` \2", text)
+
         # Merge general accidental newlines inside sentences
         lines = text.splitlines()
         merged_lines = []
@@ -82,6 +93,7 @@ def postprocess_text(text: str, url: str) -> str:
                     continue
             merged_lines.append(line)
         text = "\n".join(merged_lines)
+
         # Remove empty lines between consecutive list items to keep list blocks compact
         lines = text.splitlines()
         new_lines = []
@@ -99,7 +111,14 @@ def postprocess_text(text: str, url: str) -> str:
                         new_lines.pop()
             new_lines.append(line)
         text = "\n".join(new_lines)
-    return text
+        return text
+
+
+def get_processor(url: str) -> BaseProcessor:
+    """Return the appropriate HTML/text processor for the given URL."""
+    if "news.hada.io" in url:
+        return GeekNewsProcessor()
+    return DefaultProcessor()
 
 
 def normalize_url(url: str) -> str:
@@ -149,8 +168,11 @@ def main(output_path: str, url: str) -> None:
     # Normalize the URL
     normalized_url = normalize_url(final_url)
 
+    # Get the appropriate HTML/text processor based on the URL
+    processor = get_processor(final_url)
+
     # Preprocess html to preserve list items and newlines specifically for Geek News
-    preprocessed_bytes = preprocess_html(page_html_bytes, final_url)
+    preprocessed_bytes = processor.preprocess_html(page_html_bytes)
 
     # Extract content using trafilatura
     # output_format="json" with with_metadata=True gives a JSON string with metadata
@@ -168,7 +190,7 @@ def main(output_path: str, url: str) -> None:
         )
         if formatted_text:
             # Postprocess text based on domain specific rules
-            formatted_text = postprocess_text(formatted_text, final_url)
+            formatted_text = processor.postprocess_text(formatted_text)
             trafilatura_data["text"] = formatted_text
     else:
         trafilatura_data = {}

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import time
 from logging import getLogger
 from urllib.parse import urlparse
@@ -13,6 +14,20 @@ from endpoint.readit.core import Blackboard
 
 logger = getLogger(__name__)
 logger.setLevel(os.environ.get("ENTRYPOINT_LOG_LEVEL", "INFO").upper())
+
+
+def preprocess_html(html_bytes: bytes) -> bytes:
+    """Preprocess HTML to preserve list item separation and newlines in trafilatura."""
+    try:
+        html = html_bytes.decode("utf-8", errors="replace")
+        # Replace list items with paragraph tags to preserve list item separation and newlines
+        html = re.sub(r"<li>", "<p>- ", html, flags=re.IGNORECASE)
+        html = re.sub(r"</li>", "</p>", html, flags=re.IGNORECASE)
+        # Replace br tags with paragraph boundaries to preserve single line breaks
+        html = re.sub(r"<br\s*/?>", "</p><p>", html, flags=re.IGNORECASE)
+        return html.encode("utf-8")
+    except Exception:
+        return html_bytes
 
 
 def normalize_url(url: str) -> str:
@@ -62,13 +77,24 @@ def main(output_path: str, url: str) -> None:
     # Normalize the URL
     normalized_url = normalize_url(final_url)
 
+    # Preprocess html to preserve list items and newlines
+    preprocessed_bytes = preprocess_html(page_html_bytes)
+
     # Extract content using trafilatura
     # output_format="json" with with_metadata=True gives a JSON string with metadata
     trafilatura_json_str = trafilatura.extract(
-        page_html_bytes, output_format="json", with_metadata=True
+        preprocessed_bytes, output_format="json", with_metadata=True
     )
     if trafilatura_json_str:
         trafilatura_data = json.loads(trafilatura_json_str)
+        # Extract content with markdown formatting and without comments
+        formatted_text = trafilatura.extract(
+            preprocessed_bytes,
+            include_comments=False,
+            include_formatting=True,
+        )
+        if formatted_text:
+            trafilatura_data["text"] = formatted_text
     else:
         trafilatura_data = {}
 

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -114,10 +114,26 @@ class GeekNewsProcessor(BaseProcessor):
         return text
 
 
+class LinkedInProcessor(BaseProcessor):
+    """LinkedIn specific HTML and text pre/postprocessor."""
+
+    def postprocess_text(self, text: str) -> str:
+        # Match markdown links containing comments or comment_actor in their target and strip everything from there
+        pattern = re.compile(
+            r"\[[^\]]+\]\([^\)]*(?:comment_actor|see-more-comments)[^\)]*\)"
+        )
+        match = pattern.search(text)
+        if match:
+            text = text[: match.start()].strip()
+        return text
+
+
 def get_processor(url: str) -> BaseProcessor:
     """Return the appropriate HTML/text processor for the given URL."""
     if "news.hada.io" in url:
         return GeekNewsProcessor()
+    if "linkedin.com" in url:
+        return LinkedInProcessor()
     return DefaultProcessor()
 
 

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -33,6 +33,75 @@ def preprocess_html(html_bytes: bytes, url: str) -> bytes:
         return html_bytes
 
 
+def merge_link_and_header(text: str, url: str) -> str:
+    """If Geek News, merge the top link and the title header into a single unified clickable header."""
+    if "news.hada.io" not in url:
+        return text
+
+    link_match = re.search(r"^\[([^\]]+)\]\((https?://[^\)]+)\)", text.strip())
+    if link_match:
+        link_text, link_url = link_match.groups()
+        header_match = re.search(r"#\s+([^\n]+)", text)
+        if header_match:
+            header_text = header_match.group(1).strip()
+            # Remove the top link and its trailing spaces/newlines
+            cleaned_text = re.sub(r"^\[[^\]]+\]\([^\)]+\)\s*", "", text.strip())
+            # Replace '# Title' with '# [Title](URL)'
+            return re.sub(
+                r"#\s+" + re.escape(header_text),
+                f"# [{header_text}]({link_url})",
+                cleaned_text,
+                count=1,
+            )
+    return text
+
+
+def postprocess_text(text: str, url: str) -> str:
+    """Postprocess the extracted markdown text based on URL specific rules."""
+    if "news.hada.io" in url:
+        # Strip comments section from GeekNews
+        for delimiter in ["## 댓글과 토론", "## 댓글"]:
+            if delimiter in text:
+                text = text.split(delimiter)[0].strip()
+        # Merge the top link and title header for GeekNews into a single unified clickable header
+        text = merge_link_and_header(text, url)
+        # Merge inline code backticks followed by newlines and a lowercase/Korean character
+        pattern_backtick = r"`([^`\n]+)`\s*\n+\s*([가-힣a-z,.?!~])"
+        text = re.sub(pattern_backtick, r"`\1` \2", text)
+        # Merge general accidental newlines inside sentences
+        lines = text.splitlines()
+        merged_lines = []
+        for line in lines:
+            if merged_lines and merged_lines[-1].strip() and line.strip():
+                prev_line = merged_lines[-1].rstrip()
+                curr_line = line.strip()
+                if not prev_line.endswith(
+                    (".", "!", "?", ":", "#", "-", "*")
+                ) and re.match(r"^[가-힣a-z]", curr_line):
+                    merged_lines[-1] = prev_line + " " + curr_line
+                    continue
+            merged_lines.append(line)
+        text = "\n".join(merged_lines)
+        # Remove empty lines between consecutive list items to keep list blocks compact
+        lines = text.splitlines()
+        new_lines = []
+        for i, line in enumerate(lines):
+            if line.strip().startswith("- ") and i > 0:
+                last_non_empty = None
+                for prev in reversed(new_lines):
+                    if prev.strip():
+                        last_non_empty = prev.strip()
+                        break
+                if last_non_empty and (
+                    last_non_empty.startswith("- ") or last_non_empty.startswith("* ")
+                ):
+                    while new_lines and not new_lines[-1].strip():
+                        new_lines.pop()
+            new_lines.append(line)
+        text = "\n".join(new_lines)
+    return text
+
+
 def normalize_url(url: str) -> str:
     parsed_url = urlparse(url)
     if parsed_url.netloc == "www.linkedin.com":
@@ -98,10 +167,8 @@ def main(output_path: str, url: str) -> None:
             include_links=True,
         )
         if formatted_text:
-            # Strip comments section from GeekNews
-            for delimiter in ["## 댓글과 토론", "## 댓글"]:
-                if delimiter in formatted_text:
-                    formatted_text = formatted_text.split(delimiter)[0].strip()
+            # Postprocess text based on domain specific rules
+            formatted_text = postprocess_text(formatted_text, final_url)
             trafilatura_data["text"] = formatted_text
     else:
         trafilatura_data = {}

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -16,8 +16,11 @@ logger = getLogger(__name__)
 logger.setLevel(os.environ.get("ENTRYPOINT_LOG_LEVEL", "INFO").upper())
 
 
-def preprocess_html(html_bytes: bytes) -> bytes:
-    """Preprocess HTML to preserve list item separation and newlines in trafilatura."""
+def preprocess_html(html_bytes: bytes, url: str) -> bytes:
+    """Preprocess HTML to preserve list item separation and newlines in trafilatura specifically for Geek News."""
+    if "news.hada.io" not in url:
+        return html_bytes
+
     try:
         html = html_bytes.decode("utf-8", errors="replace")
         # Replace list items with paragraph tags to preserve list item separation and newlines
@@ -77,8 +80,8 @@ def main(output_path: str, url: str) -> None:
     # Normalize the URL
     normalized_url = normalize_url(final_url)
 
-    # Preprocess html to preserve list items and newlines
-    preprocessed_bytes = preprocess_html(page_html_bytes)
+    # Preprocess html to preserve list items and newlines specifically for Geek News
+    preprocessed_bytes = preprocess_html(page_html_bytes, final_url)
 
     # Extract content using trafilatura
     # output_format="json" with with_metadata=True gives a JSON string with metadata
@@ -92,8 +95,13 @@ def main(output_path: str, url: str) -> None:
             preprocessed_bytes,
             include_comments=False,
             include_formatting=True,
+            include_links=True,
         )
         if formatted_text:
+            # Strip comments section from GeekNews
+            for delimiter in ["## 댓글과 토론", "## 댓글"]:
+                if delimiter in formatted_text:
+                    formatted_text = formatted_text.split(delimiter)[0].strip()
             trafilatura_data["text"] = formatted_text
     else:
         trafilatura_data = {}

--- a/src/endpoint/readit/app/fetch.py
+++ b/src/endpoint/readit/app/fetch.py
@@ -125,6 +125,11 @@ class LinkedInProcessor(BaseProcessor):
         match = pattern.search(text)
         if match:
             text = text[: match.start()].strip()
+        # Remove lines that contain only 3 or more repetitions of =, -, _, *, or spaces/tabs
+        pattern_separator = re.compile(
+            r"^\s*(?:={3,}|-{3,}|_{3,}|\*{3,})\s*$", re.MULTILINE
+        )
+        text = pattern_separator.sub("", text)
         return text
 
 

--- a/src/endpoint/readit/app/send_to_personal.py
+++ b/src/endpoint/readit/app/send_to_personal.py
@@ -152,6 +152,28 @@ class PersonalStorage:
             bb.personal_archive.comment_oid = comment_resp.id
             bb.personal_archive.comment_url = comment_resp.url
 
+        # Add original content as a comment if available
+        body_text = (bb.trafilatura or {}).get("text")
+        if body_text:
+            max_length = 60000
+            if len(body_text) > max_length:
+                truncated_text = body_text[:max_length]
+                content_comment_body = (
+                    "## Original Content\n\n"
+                    f"{truncated_text}\n\n"
+                    "---\n"
+                    "*Note: The content was truncated because it exceeded the character limit.*"
+                )
+            else:
+                content_comment_body = f"## Original Content\n\n{body_text}"
+
+            content_comment_resp = AddIssueComment(
+                subjectId=issue_oid,
+                body=content_comment_body,
+            ).execute(self._client)
+            bb.personal_archive.content_comment_oid = content_comment_resp.id
+            bb.personal_archive.content_comment_url = content_comment_resp.url
+
 
 def send_to_personal(bb: Blackboard, dry_run: bool) -> None:
     storage = PersonalStorage()

--- a/src/endpoint/readit/app/send_to_personal.py
+++ b/src/endpoint/readit/app/send_to_personal.py
@@ -164,13 +164,13 @@ class PersonalStorage:
         if len(body_text) > max_length:
             truncated_text = body_text[:max_length]
             content_comment_body = (
-                "## Original Content\n\n"
+                "<!-- type: original_content -->\n"
                 f"{truncated_text}\n\n"
                 "---\n"
                 "*Note: The content was truncated because it exceeded the character limit.*"
             )
         else:
-            content_comment_body = f"## Original Content\n\n{body_text}"
+            content_comment_body = f"<!-- type: original_content -->\n{body_text}"
 
         content_comment_resp = AddIssueComment(
             subjectId=issue_oid,

--- a/src/endpoint/readit/app/send_to_personal.py
+++ b/src/endpoint/readit/app/send_to_personal.py
@@ -153,26 +153,31 @@ class PersonalStorage:
             bb.personal_archive.comment_url = comment_resp.url
 
         # Add original content as a comment if available
-        body_text = (bb.trafilatura or {}).get("text")
-        if body_text:
-            max_length = 60000
-            if len(body_text) > max_length:
-                truncated_text = body_text[:max_length]
-                content_comment_body = (
-                    "## Original Content\n\n"
-                    f"{truncated_text}\n\n"
-                    "---\n"
-                    "*Note: The content was truncated because it exceeded the character limit.*"
-                )
-            else:
-                content_comment_body = f"## Original Content\n\n{body_text}"
+        self._add_original_content_comment(bb, issue_oid)
 
-            content_comment_resp = AddIssueComment(
-                subjectId=issue_oid,
-                body=content_comment_body,
-            ).execute(self._client)
-            bb.personal_archive.content_comment_oid = content_comment_resp.id
-            bb.personal_archive.content_comment_url = content_comment_resp.url
+    def _add_original_content_comment(self, bb: Blackboard, issue_oid: str) -> None:
+        body_text = (bb.trafilatura or {}).get("text")
+        if not body_text:
+            return
+
+        max_length = 60000
+        if len(body_text) > max_length:
+            truncated_text = body_text[:max_length]
+            content_comment_body = (
+                "## Original Content\n\n"
+                f"{truncated_text}\n\n"
+                "---\n"
+                "*Note: The content was truncated because it exceeded the character limit.*"
+            )
+        else:
+            content_comment_body = f"## Original Content\n\n{body_text}"
+
+        content_comment_resp = AddIssueComment(
+            subjectId=issue_oid,
+            body=content_comment_body,
+        ).execute(self._client)
+        bb.personal_archive.content_comment_oid = content_comment_resp.id
+        bb.personal_archive.content_comment_url = content_comment_resp.url
 
 
 def send_to_personal(bb: Blackboard, dry_run: bool) -> None:

--- a/src/endpoint/readit/app/send_to_queue_v2.py
+++ b/src/endpoint/readit/app/send_to_queue_v2.py
@@ -51,6 +51,8 @@ class Queue:
     OTHER_KEY_SENTENCES_URL_FIELD_ID = "PVTF_lAHOAOPA3c4BWG6ZzhRdy4E"
     OTHER_KEY_SENTENCES_ID_FIELD_ID = "PVTF_lAHOAOPA3c4BWG6ZzhSI5iA"
     OTHER_URL_FIELD_ID = "PVTF_lAHOAOPA3c4BWG6ZzhReQy0"
+    OTHER_CONTENT_URL_FIELD_ID = "PVTF_lAHOAOPA3c4BWG6ZzhTMTCA"
+    OTHER_CONTENT_ID_FIELD_ID = "PVTF_lAHOAOPA3c4BWG6ZzhTMTDk"
 
     def __init__(self):
         github_graphql_url = os.environ["GITHUB_GRAPHQL_URL"]
@@ -121,7 +123,7 @@ class Queue:
                 projectId=self.OTHER_PROJECT_ID,
                 itemId=item_id,
                 fieldId=self.OTHER_KEY_SENTENCES_URL_FIELD_ID,
-                value=str(summary_url),
+                value=summary_url,
             ).execute(self._client)
 
         UpdateTextFieldValue(
@@ -130,6 +132,25 @@ class Queue:
             fieldId=self.OTHER_KEY_SENTENCES_ID_FIELD_ID,
             value=comment_oid,
         ).execute(self._client)
+
+        # Use content_comment_url (where original content is) if available
+        content_url = bb.personal_archive.content_comment_url
+        if content_url:
+            UpdateTextFieldValue(
+                projectId=self.OTHER_PROJECT_ID,
+                itemId=item_id,
+                fieldId=self.OTHER_CONTENT_URL_FIELD_ID,
+                value=content_url,
+            ).execute(self._client)
+
+        content_oid = bb.personal_archive.content_comment_oid
+        if content_oid:
+            UpdateTextFieldValue(
+                projectId=self.OTHER_PROJECT_ID,
+                itemId=item_id,
+                fieldId=self.OTHER_CONTENT_ID_FIELD_ID,
+                value=content_oid,
+            ).execute(self._client)
 
     def _add_arxiv(self, bb: Blackboard):
         # TODO: Move arxiv_id extraction to Blackboard model or fetcher in the future

--- a/src/endpoint/readit/core.py
+++ b/src/endpoint/readit/core.py
@@ -25,8 +25,10 @@ class PersonalArchiveMetadata(BaseModel):
     issue_url: str | None = None
     comment_oid: str | None = None
     comment_url: str | None = None
+    content_comment_oid: str | None = None
+    content_comment_url: str | None = None
 
-    @field_validator("issue_url", "comment_url")
+    @field_validator("issue_url", "comment_url", "content_comment_url")
     @classmethod
     def validate_url(cls, v: str | None) -> str | None:
         if v is not None:

--- a/src/endpoint/readit/github.py
+++ b/src/endpoint/readit/github.py
@@ -99,6 +99,38 @@ class AddIssueComment:
         )
 
 
+@dataclass(frozen=True)
+class UpdateIssueCommentResponse:
+    id: str
+    body: str
+
+
+class UpdateIssueComment:
+    # https://docs.github.com/en/graphql/reference/mutations#updateissuecomment
+    QUERY = gql("""
+    mutation ($id: ID!, $body: String!) {
+      op: updateIssueComment(input: {
+        id: $id,
+        body: $body,
+      }) { issueComment { id body } }
+    }
+    """)
+
+    def __init__(self, *, id: str, body: str):
+        self._values = {
+            "id": id,
+            "body": body,
+        }
+
+    def execute(self, client) -> UpdateIssueCommentResponse:
+        result = client.execute(self.QUERY, variable_values=self._values)
+        logger.debug(result)
+        return UpdateIssueCommentResponse(
+            id=result["op"]["issueComment"]["id"],
+            body=result["op"]["issueComment"]["body"],
+        )
+
+
 class UpdateTextFieldValue:
     # https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue
     QUERY = gql("""

--- a/tests/endpoint/readit/test_core.py
+++ b/tests/endpoint/readit/test_core.py
@@ -1,6 +1,7 @@
 import pytest
 from endpoint.readit.core import Blackboard
 from endpoint.readit.core import ArxivMetadata
+from endpoint.readit.core import PersonalArchiveMetadata
 
 
 def test_blackboard_arxiv_validation():
@@ -11,6 +12,7 @@ def test_blackboard_arxiv_validation():
         kind="arxiv",
         arxiv=ArxivMetadata(summary="Summary", year="2024"),
     )
+    assert bb.arxiv is not None
     assert bb.arxiv.year == "2024"
 
     # Invalid arxiv (missing arxiv field)
@@ -22,3 +24,24 @@ def test_blackboard_url_as_str():
     """Test the url_as_str method of Blackboard."""
     bb = Blackboard(url="https://example.com/foo")
     assert bb.url_as_str() == "https://example.com/foo"
+
+
+def test_personal_archive_metadata_validation():
+    """Test PersonalArchiveMetadata validation for comments and issues."""
+    meta = PersonalArchiveMetadata(
+        issue_oid="ISSUE_OID",
+        issue_url="https://github.com/parjong/companion/issues/1",
+        comment_oid="COMMENT_OID",
+        comment_url="https://github.com/parjong/companion/issues/1#issuecomment-1",
+        content_comment_oid="CONTENT_COMMENT_OID",
+        content_comment_url="https://github.com/parjong/companion/issues/1#issuecomment-2",
+    )
+    assert meta.content_comment_oid == "CONTENT_COMMENT_OID"
+    assert (
+        meta.content_comment_url
+        == "https://github.com/parjong/companion/issues/1#issuecomment-2"
+    )
+
+    # Invalid URL validation
+    with pytest.raises(ValueError):
+        PersonalArchiveMetadata(content_comment_url="invalid-url")

--- a/tests/endpoint/readit/test_send_to_personal.py
+++ b/tests/endpoint/readit/test_send_to_personal.py
@@ -1,0 +1,90 @@
+from unittest.mock import patch
+from endpoint.readit.core import Blackboard
+from endpoint.readit.core import OtherMetadata
+from endpoint.readit.app.send_to_personal import send_to_personal
+from endpoint.readit.github import AddIssueCommentResponse
+from endpoint.readit.github import CreateIssueResponse
+
+
+def test_send_to_personal_other_article(monkeypatch):
+    """Test send_to_personal for 'other' kind with dry_run."""
+    monkeypatch.setenv("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
+    monkeypatch.setenv("OWNER_TOKEN", "dummy-token")
+
+    bb = Blackboard(
+        url="https://example.com/some-article",
+        kind="other",
+        title="Some Test Article",
+        date="2026/05/18",
+        trafilatura={"text": "This is the body content of the test article."},
+        other=OtherMetadata(
+            key_sentences=["Key sentence 1", "Key sentence 2"],
+        ),
+    )
+
+    # Let's call send_to_personal with dry_run=True
+    send_to_personal(bb, dry_run=True)
+
+    # Verify that the personal archive metadata is populated
+    assert bb.personal_archive.issue_oid == "DUMMY_ISSUE_ID"
+    assert bb.personal_archive.issue_url == "https://github.com/dummy/issue/1"
+    assert bb.personal_archive.comment_oid == "DUMMY_COMMENT_ID"
+    assert (
+        bb.personal_archive.comment_url
+        == "https://github.com/dummy/issue/1#issuecomment-1"
+    )
+    assert bb.personal_archive.content_comment_oid == "DUMMY_COMMENT_ID"
+    assert (
+        bb.personal_archive.content_comment_url
+        == "https://github.com/dummy/issue/1#issuecomment-1"
+    )
+
+
+def test_send_to_personal_other_article_truncated(monkeypatch):
+    """Test send_to_personal truncation logic for very long content."""
+    monkeypatch.setenv("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
+    monkeypatch.setenv("OWNER_TOKEN", "dummy-token")
+
+    # Body text longer than 60,000 characters
+    long_body = "A" * 65000
+    bb = Blackboard(
+        url="https://example.com/long-article",
+        kind="other",
+        title="Long Test Article",
+        date="2026/05/18",
+        trafilatura={"text": long_body},
+    )
+
+    # We want to intercept CreateIssue and AddIssueComment execute call to inspect the body that was sent!
+    original_execute = []
+
+    def mock_create_issue(self, client):
+        return CreateIssueResponse(
+            id="DUMMY_ISSUE_ID", url="https://github.com/dummy/issue/1"
+        )
+
+    # We patch AddIssueComment.execute so we can capture the comment body
+    def mock_add_comment(self, client):
+        original_execute.append(self._values["body"])
+        return AddIssueCommentResponse(
+            id="TRUNCATED_COMMENT_ID",
+            url="https://github.com/dummy/issue/1#issuecomment-truncated",
+        )
+
+    with patch("endpoint.readit.github.CreateIssue.execute", mock_create_issue):
+        with patch("endpoint.readit.github.AddIssueComment.execute", mock_add_comment):
+            send_to_personal(bb, dry_run=False)
+
+    # There should be exactly 1 comment since key_sentences is empty, which is the original content comment
+    assert len(original_execute) == 1
+    comment_body = original_execute[0]
+    assert comment_body.startswith("## Original Content\n\n")
+    assert "truncated because it exceeded the character limit" in comment_body
+    # The actual truncated body should be exactly 60,000 "A"s
+    truncated_content = comment_body.split("\n\n")[1]
+    assert len(truncated_content) == 60000
+    assert bb.personal_archive.content_comment_oid == "TRUNCATED_COMMENT_ID"
+    assert (
+        bb.personal_archive.content_comment_url
+        == "https://github.com/dummy/issue/1#issuecomment-truncated"
+    )

--- a/tests/endpoint/readit/test_send_to_personal.py
+++ b/tests/endpoint/readit/test_send_to_personal.py
@@ -78,10 +78,12 @@ def test_send_to_personal_other_article_truncated(monkeypatch):
     # There should be exactly 1 comment since key_sentences is empty, which is the original content comment
     assert len(original_execute) == 1
     comment_body = original_execute[0]
-    assert comment_body.startswith("## Original Content\n\n")
+    assert comment_body.startswith("<!-- type: original_content -->\n")
     assert "truncated because it exceeded the character limit" in comment_body
     # The actual truncated body should be exactly 60,000 "A"s
-    truncated_content = comment_body.split("\n\n")[1]
+    truncated_content = comment_body.replace(
+        "<!-- type: original_content -->\n", ""
+    ).split("\n\n")[0]
     assert len(truncated_content) == 60000
     assert bb.personal_archive.content_comment_oid == "TRUNCATED_COMMENT_ID"
     assert (

--- a/tests/endpoint/readit/test_send_to_queue_v2.py
+++ b/tests/endpoint/readit/test_send_to_queue_v2.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+from endpoint.readit.core import Blackboard
+from endpoint.readit.core import PersonalArchiveMetadata
+from endpoint.readit.github import ProjectItemID
+from endpoint.readit.app.send_to_queue_v2 import send_to_queue_v2
+
+
+def test_send_to_queue_v2_other(monkeypatch):
+    """Test send_to_queue_v2 for other article kind with original content fields."""
+    monkeypatch.setenv("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
+    monkeypatch.setenv("OWNER_TOKEN", "dummy-token")
+
+    bb = Blackboard(
+        url="https://example.com/other-article",
+        kind="other",
+        title="Test Other Queue Article",
+        date="2026/05/18",
+        personal_archive=PersonalArchiveMetadata(
+            issue_oid="DUMMY_ISSUE_ID",
+            issue_url="https://github.com/dummy/issue/1",
+            comment_oid="DUMMY_COMMENT_ID",
+            comment_url="https://github.com/dummy/issue/1#issuecomment-1",
+            content_comment_oid="DUMMY_CONTENT_COMMENT_ID",
+            content_comment_url="https://github.com/dummy/issue/1#issuecomment-2",
+        ),
+    )
+
+    # Capture the fields updated
+    updated_fields = {}
+
+    def mock_add_project_v2_execute(self, client):
+        return ProjectItemID("DUMMY_ITEM_ID")
+
+    def mock_add_project_v2_item_execute(self, client):
+        return ProjectItemID("DUMMY_ITEM_ID")
+
+    def mock_update_text_field(self, client):
+        field_id = self._values["fieldId"]
+        value = self._values["value"]
+        updated_fields[field_id] = value
+
+    with patch(
+        "endpoint.readit.app.send_to_queue_v2.AddProjectV2DraftIssue.execute",
+        mock_add_project_v2_execute,
+    ):
+        with patch(
+            "endpoint.readit.github.AddProjectV2ItemById.execute",
+            mock_add_project_v2_item_execute,
+        ):
+            with patch(
+                "endpoint.readit.app.send_to_queue_v2.UpdateTextFieldValue.execute",
+                mock_update_text_field,
+            ):
+                send_to_queue_v2(bb, dry_run=False)
+
+    # Verify that the original content fields are updated on the project item!
+    # OTHER_CONTENT_URL_FIELD_ID = "PVTF_lAHOAOPA3c4BWG6ZzhTMTCA"
+    # OTHER_CONTENT_ID_FIELD_ID = "PVTF_lAHOAOPA3c4BWG6ZzhTMTDk"
+    assert (
+        updated_fields["PVTF_lAHOAOPA3c4BWG6ZzhTMTCA"]
+        == "https://github.com/dummy/issue/1#issuecomment-2"
+    )
+    assert updated_fields["PVTF_lAHOAOPA3c4BWG6ZzhTMTDk"] == "DUMMY_CONTENT_COMMENT_ID"


### PR DESCRIPTION
Let's add the original content comment and store its ID and URL in PersonalArchiveMetadata to preserve the full original text of other articles.

This PR implements the following changes:
1. In `src/endpoint/readit/core.py`, added `content_comment_oid` and `content_comment_url` to `PersonalArchiveMetadata` and validated `content_comment_url`.
2. In `src/endpoint/readit/app/send_to_personal.py`, extracted original content via `trafilatura`, formatted, and posted it as an issue comment under a safety threshold of 60,000 characters to prevent GraphQL payload overflow. Stored the comment ID and URL in the blackboard object.
3. Created a comprehensive suite of unit tests in `tests/endpoint/readit/test_send_to_personal.py` and added validations in `tests/endpoint/readit/test_core.py`.

Resolve #112
